### PR TITLE
Inclusion of item.verb both in import and export

### DIFF
--- a/src/generators/router.ts.ts
+++ b/src/generators/router.ts.ts
@@ -9,11 +9,11 @@ export class RouterTsOptions {
 export class RouterTsGenerator extends BaseGenerator {
     contents = `import * as express from 'express';
 import { ${this.options.config.map(item => `
-    ${item.controller}_${item.function}`).join(',')} } from './controllers'
+    ${item.controller}_${item.function}_${item.verb}`).join(',')} } from './controllers'
 export default express.Router()${this.options.config.map(item => `
 .${item.verb}('/${item.plainController}/${item.function}${item.params && item.verb === HTTP_VERBS.GET ?
             item.params.map(param => `/:` + param.name).join('')
-            : ''}', ${item.controller}_${item.function})`).join('')}
+            : ''}', ${item.controller}_${item.function}_${item.verb})`).join('')}
 `;
 
     constructor(filename: string, path: string, private options: RouterTsOptions) {


### PR DESCRIPTION
Due to TS compilation error, it is necessary to include the `item.verb` into the router import and export.