### PR TITLE
feat: read the query flag to produce query invokes

### DIFF
--- a/src/generators/controller.ts.ts
+++ b/src/generators/controller.ts.ts
@@ -15,12 +15,12 @@ ${this.options.config.map(item => `
 export async function ${item.controller}_${item.function}_${item.verb}(req: Request, res: Response): Promise<void>{
     try{
         ${item.verb === HTTP_VERBS.GET ? `let params = req.params;
-        res.status(200).send(await ${item.controller}BackEnd
+        res.status(200).send(await ${item.controller}BackEnd${item.query ? '.$query()' : ''}
             .${item.function}(${item.params ? item.params.map(param => `params.` + param.name).join(',') : ''}));
         ` :
             !item.verb || item.verb === HTTP_VERBS.POST || item.verb === HTTP_VERBS.PUT
                 || item.verb === HTTP_VERBS.DELETE ? `let params = req.body;
-            res.status(200).send(await ${item.controller}BackEnd
+            res.status(200).send(await ${item.controller}BackEnd${item.query ? '.$query()' : ''}
                 .${item.function}(${item.params ? item.params.map(param => `params.` + param.name).join(',') : ''}));
             `: ''}
     } catch(ex) {

--- a/src/models/apiConfigurationFile.ts
+++ b/src/models/apiConfigurationFile.ts
@@ -6,6 +6,7 @@ export class ApiConfigurationItem {
     verb: HTTP_VERBS = HTTP_VERBS.POST;
     returns = false;
     controller: string;
+    query = false;
     params: {
         name: string,
         type: string
@@ -14,11 +15,12 @@ export class ApiConfigurationItem {
     get plainController() {
         return this.controller.replace('Controller', '').toLowerCase();
     }
-    constructor(params: { function: string, verb: HTTP_VERBS, returns: boolean, controller: string }) {
+    constructor(params: { function: string, verb: HTTP_VERBS, returns: boolean, controller: string, query?: boolean }) {
         this.function = params.function;
         this.verb = params.verb || HTTP_VERBS.POST;
         this.returns = params.returns || false;
         this.controller = params.controller;
+        this.query = params.query || false;
     }
 }
 


### PR DESCRIPTION
Allow to pass a param in api.json to generate query invokes
```
[
  {
    "query": true
  }
]
```

Will produce an invoke like `ctrl.$query().method()`