### PR TITLE
fix: update chai typings for patch versions only

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "update-notifier": "^2.5.0"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
+    "@types/chai": "~4.1.7",
     "@types/fs-extra": "^5.0.4",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.20",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Actually if we do an npm install the operation will fail doing a post install process
Also, is not posible to make a build

This is because a minor update of chai's typings introduces a breaking change.

Issue Number: #13 

## What is the new behavior?

The install process is clean and completes without error and we can make a build.
We only accept patch versions of chai's typings

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The problem was a chai typing that introduce a braking change in its last version 4.x.x.

The solution is only accepting patch versions of that typing 4.1.x